### PR TITLE
Added cache busting to getQuizSession

### DIFF
--- a/src/main/default/classes/QuizController.cls
+++ b/src/main/default/classes/QuizController.cls
@@ -16,8 +16,9 @@ public with sharing class QuizController {
         return playerService.getPlayersSortedByScore(maxFetchCount);
     }
 
+    // Using timestamp parameter as a cache buster
     @AuraEnabled
-    public static Quiz_Session__c getQuizSession() {
+    public static Quiz_Session__c getQuizSession(Long timestamp) {
         return quizSessionService.getQuizSession();
     }     
 }

--- a/src/main/default/lwc/gameApp/gameApp.js
+++ b/src/main/default/lwc/gameApp/gameApp.js
@@ -33,7 +33,7 @@ export default class GameApp extends LightningElement {
     }
 
     connectedCallback() {
-        getQuizSession()
+        getQuizSession({ timestamp: Date.now() })
             .then(data => {
                 this.quizSession = data;
                 // no session and no error returned


### PR DESCRIPTION
`QuizController.getQuizSession()` was getting cached and this was messing up UI for `gameApp` component. I busted the cache by introducing a timestamp parameter (removing `@AuraEnabled(cacheable=true)` didn't work).