### PR TITLE
Install script fails on import data

### DIFF
--- a/data/Quiz_Question__c-Quiz_Session__c-Quiz_Session_Question__c-plan.json
+++ b/data/Quiz_Question__c-Quiz_Session__c-Quiz_Session_Question__c-plan.json
@@ -2,7 +2,7 @@
     {
         "sobject": "Quiz_Question__c",
         "saveRefs": true,
-        "resolveRefs": false,
+        "resolveRefs": true,
         "files": ["Quiz_Question__cs.json"]
     },
     {

--- a/data/Quiz_Question__cs.json
+++ b/data/Quiz_Question__cs.json
@@ -5,7 +5,6 @@
                 "type": "Quiz_Question__c",
                 "referenceId": "Quiz_Question__cRef1"
             },
-            "Name": "Q-0000",
             "Label__c": "What does SLDS stand for?",
             "Answer_A__c": "Super Light Debugging Solution",
             "Answer_B__c": "Salesforce Lightning Design System",
@@ -18,7 +17,6 @@
                 "type": "Quiz_Question__c",
                 "referenceId": "Quiz_Question__cRef2"
             },
-            "Name": "Q-0002",
             "Label__c": "What is the API version for Winter 20?",
             "Answer_A__c": "45.0",
             "Answer_B__c": "47.0",
@@ -31,7 +29,6 @@
                 "type": "Quiz_Question__c",
                 "referenceId": "Quiz_Question__cRef3"
             },
-            "Name": "Q-0001",
             "Label__c": "How many streaming APIs exist?",
             "Answer_A__c": "1",
             "Answer_B__c": "2",

--- a/data/Quiz_Session__cs.json
+++ b/data/Quiz_Session__cs.json
@@ -5,7 +5,6 @@
                 "type": "Quiz_Session__c",
                 "referenceId": "Quiz_Session__cRef1"
             },
-            "Name": "QS-0001",
             "Phase__c": "Registration",
             "Current_Question__c": "@Quiz_Question__cRef1"
         }

--- a/install-dev.sh
+++ b/install-dev.sh
@@ -26,7 +26,7 @@ sfdx force:user:permset:assign -n Quiz_Admin -u $ORG_ALIAS && \
 echo "" && \
 
 echo "Importing data..." && \
-sfdx force:data:tree:import -p data/plan.json -u $ORG_ALIAS && \
+sfdx force:data:tree:import -p data/Quiz_Question__c-Quiz_Session__c-Quiz_Session_Question__c-plan.json -u $ORG_ALIAS && \
 echo ""
 
 EXIT_CODE="$?"


### PR DESCRIPTION
- fix install script to call the appropriate plan.json
- remove the Name field of Quiz Session and Quiz Question. The import was failing due to those fields being non-write-able from the API

On running 
`sfdx force:data:tree:import -p data/Quiz_Question__c-Quiz_Session__c-Quiz_Session_Question__c-plan.json -u $ORG_ALIAS && \`
Got error 
```
=== Quiz_Session_Question__cRef1 [1]
STATUSCODE    MESSAGE                                                    FIELDS
────────────  ─────────────────────────────────────────────────────────  ──────────
MALFORMED_ID  Session: id value of incorrect type: @Quiz_Session__cRef1  Session__c
=== Quiz_Session_Question__cRef2 [1]
STATUSCODE    MESSAGE                                                    FIELDS
────────────  ─────────────────────────────────────────────────────────  ──────────
MALFORMED_ID  Session: id value of incorrect type: @Quiz_Session__cRef1  Session__c
=== Quiz_Session_Question__cRef3 [1]
STATUSCODE    MESSAGE                                                    FIELDS
────────────  ─────────────────────────────────────────────────────────  ──────────
MALFORMED_ID  Session: id value of incorrect type: @Quiz_Session__cRef1  Session__c
ERROR running force:data:tree:import:  
```
Apparently even `resolveRefs: true` does not fix the problem. How to fix it @pozil ?