### PR TITLE
Fix stats when no answer is given

### DIFF
--- a/src/main/default/lwc/gameApp/gameApp.js
+++ b/src/main/default/lwc/gameApp/gameApp.js
@@ -41,12 +41,6 @@ export default class GameApp extends LightningElement {
     getAnswers() {
         getAnswerMap()
             .then(data => {
-                // no answers found
-                if (Object.entries(data).length === 0) {
-                    this.error = undefined;
-                    return;
-                }
-
                 // turn object {"A":1,"B":1,"D":2} into array [1, 1, 0, 2]
                 const arr = [];
                 this.labels.forEach(letter => {


### PR DESCRIPTION
Previous code was showing answers from previous question when no answers were entered in current question.

For example, I answered Q1 but did not answer Q2 in time. What I saw in Q2 QuestionResults are the two answers from Q1:
![Screenshot 2019-11-04 at 08 41 57](https://user-images.githubusercontent.com/5071767/68106029-9e17cc80-fee0-11e9-9cc0-612ad6e47ec6.png)
