### PR TITLE
Updated Installation script command for Windows users

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ cd quiz-host-app</pre>
     <p>MacOS or Linux</p>
     <pre>./install-dev.sh quiz sample</pre>
     <p>Windows</p>
-    <pre>./install-dev.bat quiz sample</pre>
+    <pre>install-dev.bat quiz sample</pre>
     <p>Once the script completes, it will open your new scratch org in a browser tab. If you close the tab or get disconnected, run this command to reopen the org <code>sfdx force:org:open -u quiz</code></p>
     </li>
     <li>Generate a <a target="_blank" href="https://help.salesforce.com/articleView?id=user_security_token.htm">security token</a> for your user</li>

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ cd quiz-host-app</pre>
     <p>MacOS or Linux</p>
     <pre>./install-dev.sh quiz sample</pre>
     <p>Windows</p>
-    <pre>install-dev.bat quiz sample</pre>
+    <pre>./install-dev.bat quiz sample</pre>
     <p>Once the script completes, it will open your new scratch org in a browser tab. If you close the tab or get disconnected, run this command to reopen the org <code>sfdx force:org:open -u quiz</code></p>
     </li>
     <li>Generate a <a target="_blank" href="https://help.salesforce.com/articleView?id=user_security_token.htm">security token</a> for your user</li>

--- a/README.md
+++ b/README.md
@@ -6,14 +6,17 @@
 
 [![GitHub Workflow](https://github.com/pozil/quiz-host-app/workflows/CI/badge.svg?branch=master)](https://github.com/pozil/quiz-host-app/actions)
 
-1. [About](#about)
-1. [Installation](#installation)
+- [Multiplayer quiz app built on Salesforce technology (host app)](#multiplayer-quiz-app-built-on-salesforce-technology-host-app)
+  - [About](#about)
+  - [Installation](#installation)
     - [Requirements](#requirements)
     - [Steps](#steps)
     - [Setting up questions](#setting-up-questions)
-1. [Usage](#usage)
-1. [Troubleshooting](#troubleshooting)
-1. [Building and contributing](#building-and-contributing)
+      - [Importing other questions](#importing-other-questions)
+      - [Adding/editing questions](#addingediting-questions)
+  - [Usage](#usage)
+  - [Troubleshooting](#troubleshooting)
+  - [Building and contributing](#building-and-contributing)
 
 ## About
 
@@ -61,7 +64,7 @@ cd quiz-host-app</pre>
     <p>MacOS or Linux</p>
     <pre>./install-dev.sh quiz sample</pre>
     <p>Windows</p>
-    <pre>./install-dev.bat quiz sample</pre>
+    <pre>install-dev.bat quiz sample</pre>
     <p>Once the script completes, it will open your new scratch org in a browser tab. If you close the tab or get disconnected, run this command to reopen the org <code>sfdx force:org:open -u quiz</code></p>
     </li>
     <li>Generate a <a target="_blank" href="https://help.salesforce.com/articleView?id=user_security_token.htm">security token</a> for your user</li>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align="center">
+﻿<div align="center">
   <img src="doc-media/quiz-icon.png" alt="Quiz icon" width="150"/>
 </div>
 
@@ -6,17 +6,14 @@
 
 [![GitHub Workflow](https://github.com/pozil/quiz-host-app/workflows/CI/badge.svg?branch=master)](https://github.com/pozil/quiz-host-app/actions)
 
-- [Multiplayer quiz app built on Salesforce technology (host app)](#multiplayer-quiz-app-built-on-salesforce-technology-host-app)
-  - [About](#about)
-  - [Installation](#installation)
+1. [About](#about)
+1. [Installation](#installation)
     - [Requirements](#requirements)
     - [Steps](#steps)
     - [Setting up questions](#setting-up-questions)
-      - [Importing other questions](#importing-other-questions)
-      - [Adding/editing questions](#addingediting-questions)
-  - [Usage](#usage)
-  - [Troubleshooting](#troubleshooting)
-  - [Building and contributing](#building-and-contributing)
+1. [Usage](#usage)
+1. [Troubleshooting](#troubleshooting)
+1. [Building and contributing](#building-and-contributing)
 
 ## About
 


### PR DESCRIPTION
The installation command `./install-dev.bat quiz sample` is not working on Windows.
`install-dev.bat quiz sample` must be used.